### PR TITLE
Update enumeration range formatting rules

### DIFF
--- a/accepted/ddlm_dictionary_style_guide.md
+++ b/accepted/ddlm_dictionary_style_guide.md
@@ -286,8 +286,8 @@ The regular expression above if formatted for readability using the additional s
 Numeric range limits of data items with the `Real` content type should be expressed using floating-point real numbers that:
 1. Include at least one digit before the decimal separator, e.g. '0.5' instead of '.5'.
 2. Include at least one digit after the decimal separator, e.g. '7.0' instead of '7.' or '7'.
-3. Include the minimal number of non-significant leading zeros that still satisfies other formatting rules, e.g. '0.25' instead of '000.25'.
-4. Include the minimal number of non-significant trailing zeros that still satisfies other formatting rules, e.g. '13.0' instead of '13.000'.
+3. Include the smallest number of non-significant leading zeros that still satisfies other formatting rules, e.g. '0.25' instead of '000.25'.
+4. Include the smallest number of non-significant trailing zeros that still satisfies other formatting rules, e.g. '13.0' instead of '13.000'.
 5. Do not include the '+' symbol, e.g. '42.0' instead '+42.0'.
 6. Do not include a signed zero, e.g. '0.0' instead of '+0.0' or '-0.0'.
 

--- a/accepted/ddlm_dictionary_style_guide.md
+++ b/accepted/ddlm_dictionary_style_guide.md
@@ -270,6 +270,14 @@ $
 ```
 The regular expression above if formatted for readability following the rules permitted by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols can be ignored).
 
+#### Examples
+```
+1:230
+0:
+:27
+-8:8
+```
+
 ### 2.5.2 Real number ranges
 
 Numeric range limits of `Real` data items should be expressed using floating-point real numbers.
@@ -295,16 +303,9 @@ $
 The regular expression above if formatted for readability following the rules permitted by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols can be ignored).
 
 #### Examples
-
-```
-# Integer ranges
-1:230
-0:
--8:8
-
-# Real number ranges
 0.0:100.0
 0.0:
+:13.0
 -180.0:180.0
 0.95:1.0
 ```

--- a/accepted/ddlm_dictionary_style_guide.md
+++ b/accepted/ddlm_dictionary_style_guide.md
@@ -263,7 +263,7 @@ Numeric range limits of data items with the `Integer` content type should be exp
 4. Do not include the '+' symbol, e.g. '42' instead '+42'.
 5. Do not include a signed zero, e.g. '0' instead of '+0' or '-0'.
 
-The following regular expression may be used to check if a limit number adheres to the formatting rules:
+The following regular expression may be used to check if a number adheres to the integer range limit formatting rules:
 ```
 ^
 (
@@ -273,7 +273,7 @@ $
 ```
 The regular expression above if formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
 
-##### Examples
+##### Examples of properly formatted integer number ranges
 ```
 1:230
 0:
@@ -286,30 +286,34 @@ The regular expression above if formatted for readability using the additional s
 Numeric range limits of data items with the `Real` content type should be expressed using floating-point real numbers that:
 1. Include at least one digit before the decimal separator, e.g. '0.5' instead of '.5'.
 2. Include at least one digit after the decimal separator, e.g. '7.0' instead of '7.' or '7'.
-3. Include the minimal number of non-significant leading zeros that still satisfy other formatting rules, e.g. '0.25' instead of '000.25'.
-4. Include the minimal number of non-significant trailing zeros that still satisfy other formatting rules, e.g. '13.0' instead of '13.000'.
+3. Include the minimal number of non-significant leading zeros that still satisfies other formatting rules, e.g. '0.25' instead of '000.25'.
+4. Include the minimal number of non-significant trailing zeros that still satisfies other formatting rules, e.g. '13.0' instead of '13.000'.
 5. Do not include the '+' symbol, e.g. '42.0' instead '+42.0'.
 6. Do not include a signed zero, e.g. '0.0' instead of '+0.0' or '-0.0'.
 
-The following regular expression may be used to check if the limit number adheres to the formatting rules:
+The following regular expression may be used to check if a number adheres to the real number range limit formatting rules:
 
 ```
 ^
 (
-  ( 0[.]0 ) |                   # Real number '0.0'.
-  ( [-]?([1-9][0-9]*)[.]0 ) |   # All integer-like numbers, e.g. '-5.0'.
-  ( [-]?(0|))[.]([0-9]*[1-9]) ) # All remaining floating-point numbers.
+  # Real number '0.0'.
+  ( 0[.]0 ) |
+  # All integer-like numbers, e.g. '-5.0'.
+  ( [-]?([1-9][0-9]*)[.]0 ) |
+  # All remaining floating-point numbers.
+  ( [-]?(0|([1-9][0-9]*))[.]([0-9]*[1-9]) )
 )
 $
 ```
 The regular expression above if formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
 
-##### Examples
+##### Examples of properly formatted real number ranges
 ```
 0.0:100.0
 0.0:
 :13.0
 -180.0:180.0
+-3.14:3.14
 0.95:1.0
 ```
 

--- a/accepted/ddlm_dictionary_style_guide.md
+++ b/accepted/ddlm_dictionary_style_guide.md
@@ -250,15 +250,18 @@ compound objects.
 
 ### 2.5 Enumeration ranges
 
+Values of the `_enumeration.range` attribute should be expressed in a format that best reflects the content type of the defining item.
+That is, numeric range limits of data items with the `Integer` content type should be formatted as integers while data items with the `Real` content type should be formatted as floating-point real numbers.
+Additional formatting rules for enumeration ranges are provided in Section 2.5.1 and Section 2.5.2.
+
 #### 2.5.1 Integer ranges
 
-Numeric range limits of `Integer` data items should be expressed as integer numbers.
-These integer numbers:
-1. Should not include non-significant leading zeros, e.g. '7' instead of '007'.
-2. Should not include a fractional part, e.g. '1' instead of '1.0'.
-3. Should not include a trailing decimal separator, e.g. '2' instead of '2.'.
-4. Should not include the '+' symbol, e.g. '42' instead '+42'.
-5. Should not include a signed zero, e.g. '0' instead of '+0' or '-0'.
+Numeric range limits of data items with the `Integer` content type should be expressed as integers that:
+1. Do not include non-significant leading zeros, e.g. '7' instead of '007'.
+2. Do not include a fractional part, e.g. '1' instead of '1.0'.
+3. Do not include a trailing decimal separator, e.g. '2' instead of '2.'.
+4. Do not include the '+' symbol, e.g. '42' instead '+42'.
+5. Do not include a signed zero, e.g. '0' instead of '+0' or '-0'.
 
 The following regular expression may be used to check if a limit number adheres to the formatting rules:
 ```
@@ -268,9 +271,9 @@ The following regular expression may be used to check if a limit number adheres 
 )
 $
 ```
-The regular expression above if formatted for readability following the rules permitted by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols can be ignored).
+The regular expression above if formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
 
-#### Examples
+##### Examples
 ```
 1:230
 0:
@@ -280,29 +283,29 @@ The regular expression above if formatted for readability following the rules pe
 
 ### 2.5.2 Real number ranges
 
-Numeric range limits of `Real` data items should be expressed using floating-point real numbers.
-These floating-point real numbers:
-1. Should include at least one digit before the decimal separator, e.g. '0.5' instead of '.5'.
-2. Should include at least one digit after the decimal separator, e.g. '7.0' instead of '7.' or '7'.
-3. Should include the minimal number of non-significant leading zeros that still satisfy other formatting rules, e.g. '0.25' instead of '000.25'.
-4. Should include the minimal number of non-significant trailing zeros that still satisfy other formatting rules, e.g. '13.0' instead of '13.000'.
-5. Should not include the '+' symbol, e.g. '42.0' instead '+42.0'.
-6. Should not include a signed zero, e.g. '0.0' instead of '+0.0' or '-0.0'.
+Numeric range limits of data items with the `Real` content type should be expressed using floating-point real numbers that:
+1. Include at least one digit before the decimal separator, e.g. '0.5' instead of '.5'.
+2. Include at least one digit after the decimal separator, e.g. '7.0' instead of '7.' or '7'.
+3. Include the minimal number of non-significant leading zeros that still satisfy other formatting rules, e.g. '0.25' instead of '000.25'.
+4. Include the minimal number of non-significant trailing zeros that still satisfy other formatting rules, e.g. '13.0' instead of '13.000'.
+5. Do not include the '+' symbol, e.g. '42.0' instead '+42.0'.
+6. Do not include a signed zero, e.g. '0.0' instead of '+0.0' or '-0.0'.
 
 The following regular expression may be used to check if the limit number adheres to the formatting rules:
 
 ```
 ^
 (
-  ( 0[.]0 ) |                   # Real number 0.0
-  ( [-]?([1-9][0-9]*)[.]0 ) |   # All integer-like numbers, e.g. -5.0
-  ( [-]?(0|))[.]([0-9]*[1-9]) ) # All remaining floating-point numbers
+  ( 0[.]0 ) |                   # Real number '0.0'.
+  ( [-]?([1-9][0-9]*)[.]0 ) |   # All integer-like numbers, e.g. '-5.0'.
+  ( [-]?(0|))[.]([0-9]*[1-9]) ) # All remaining floating-point numbers.
 )
 $
 ```
-The regular expression above if formatted for readability following the rules permitted by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols can be ignored).
+The regular expression above if formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
 
-#### Examples
+##### Examples
+```
 0.0:100.0
 0.0:
 :13.0

--- a/accepted/ddlm_dictionary_style_guide.md
+++ b/accepted/ddlm_dictionary_style_guide.md
@@ -250,10 +250,49 @@ compound objects.
 
 ### 2.5 Enumeration ranges
 
-When giving enumeration ranges for `Integer` data items, no decimal
-point should be used. When giving enumeration ranges for `Real` data
-items, a decimal point should be used with at least one digit after
-the point. Any following digits, if present, must be non-zero.
+#### 2.5.1 Integer ranges
+
+Numeric range limits of `Integer` data items should be expressed as integer numbers.
+These integer numbers:
+1. Should not include non-significant leading zeros, e.g. '7' instead of '007'.
+2. Should not include a fractional part, e.g. '1' instead of '1.0'.
+3. Should not include a trailing decimal separator, e.g. '2' instead of '2.'.
+4. Should not include the '+' symbol, e.g. '42' instead '+42'.
+5. Should not include a signed zero, e.g. '0' instead of '+0' or '-0'.
+
+The following regular expression may be used to check if a limit number adheres to the formatting rules:
+```
+^
+(
+  0|( [-]?[1-9][0-9]* )
+)
+$
+```
+The regular expression above if formatted for readability following the rules permitted by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols can be ignored).
+
+### 2.5.2 Real number ranges
+
+Numeric range limits of `Real` data items should be expressed using floating-point real numbers.
+These floating-point real numbers:
+1. Should include at least one digit before the decimal separator, e.g. '0.5' instead of '.5'.
+2. Should include at least one digit after the decimal separator, e.g. '7.0' instead of '7.' or '7'.
+3. Should include the minimal number of non-significant leading zeros that still satisfy other formatting rules, e.g. '0.25' instead of '000.25'.
+4. Should include the minimal number of non-significant trailing zeros that still satisfy other formatting rules, e.g. '13.0' instead of '13.000'.
+5. Should not include the '+' symbol, e.g. '42.0' instead '+42.0'.
+6. Should not include a signed zero, e.g. '0.0' instead of '+0.0' or '-0.0'.
+
+The following regular expression may be used to check if the limit number adheres to the formatting rules:
+
+```
+^
+(
+  ( 0[.]0 ) |                   # Real number 0.0
+  ( [-]?([1-9][0-9]*)[.]0 ) |   # All integer-like numbers, e.g. -5.0
+  ( [-]?(0|))[.]([0-9]*[1-9]) ) # All remaining floating-point numbers
+)
+$
+```
+The regular expression above if formatted for readability following the rules permitted by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols can be ignored).
 
 #### Examples
 

--- a/accepted/ddlm_dictionary_style_guide.md
+++ b/accepted/ddlm_dictionary_style_guide.md
@@ -271,7 +271,7 @@ The following regular expression may be used to check if a number adheres to the
 )
 $
 ```
-The regular expression above if formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
+The regular expression above is formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
 
 ##### Examples of properly formatted integer number ranges
 ```
@@ -305,7 +305,7 @@ The following regular expression may be used to check if a number adheres to the
 )
 $
 ```
-The regular expression above if formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
+The regular expression above is formatted for readability using the additional syntax rules enabled by the `/x` Perl regular expression modifier (e.g. any unescaped whitespace symbols must be ignored).
 
 ##### Examples of properly formatted real number ranges
 ```


### PR DESCRIPTION
Once I started to actually implement the check, I noticed that there were some additional representations of integer and floating-point numbers that we might not want to allow in enumeration ranges. Specifically, I recall that values like `0.0` were purposely replaced with `0.0` at some point.

I also added a few regular expressions since they probably will prove quite useful to people who decided to actually implement the checks.

A review from @rowlesmr would be useful since he was the main author of the original rule. However, I am unable to explicitly request a review from him, probably due to him not having sufficient permissions on the repository. @jamesrhester, could you please invite him as a collaborator, I do not seem to have sufficient permissions to do that myself.